### PR TITLE
Fix SnapScript execution engine bugs.

### DIFF
--- a/2DX-GL/snap2d/src/main/java/com/snap2d/gl/opengl/GLUtils.java
+++ b/2DX-GL/snap2d/src/main/java/com/snap2d/gl/opengl/GLUtils.java
@@ -1,12 +1,12 @@
 /*
  *  Copyright (C) 2011-2014 Brian Groenke
  *  All rights reserved.
- * 
+ *
  *  This file is part of the 2DX Graphics Library.
  *
  *  This Source Code Form is subject to the terms of the
- *  Mozilla Public License, v. 2.0. If a copy of the MPL 
- *  was not distributed with this file, You can obtain one at 
+ *  Mozilla Public License, v. 2.0. If a copy of the MPL
+ *  was not distributed with this file, You can obtain one at
  *  http://mozilla.org/MPL/2.0/.
  */
 
@@ -30,7 +30,7 @@ import com.snap2d.world.World2D;
  * Provides common utility methods for interfacing with OpenGL libraries. Some
  * members of this class simply act as forward-wrappers for JOGL/Gluegen
  * utilities.
- * 
+ *
  * @author Brian Groenke
  *
  */
@@ -83,7 +83,7 @@ public class GLUtils {
     /**
      * Writes the RGBA components of the given Color to a FloatBuffer as OpenGL
      * color values (0.0f - 1.0f).
-     * 
+     *
      * @param color
      *            the java.awt.Color to convert
      * @param colorBuff
@@ -102,7 +102,7 @@ public class GLUtils {
     /**
      * Calls {@link #writeColorToBuffer(Color, FloatBuffer)} with a newly
      * allocated FloatBuffer.
-     * 
+     *
      * @param color
      * @return
      */
@@ -114,7 +114,7 @@ public class GLUtils {
     /**
      * Converts an AWT Color (0f - 255f) linearly to GL color space (0.0f -
      * 1.0f).
-     * 
+     *
      * @param color
      *            the AWT color to convert
      * @return an array of GL color channels
@@ -132,6 +132,19 @@ public class GLUtils {
 
         System.out.print("[");
         for (int i = 0; i < buff.limit(); i++ ) {
+            System.out.print(buff.get(i));
+            if (i < buff.limit() - 1) {
+                System.out.print(", ");
+            }
+        }
+        System.out.println("]");
+    }
+
+    public static final void printBuffer(final ByteBuffer buff, boolean printPosLabels) {
+
+        System.out.print("[");
+        for (int i = 0; i < buff.limit(); i++ ) {
+            if (printPosLabels) System.out.print(i + ": ");
             System.out.print(buff.get(i));
             if (i < buff.limit() - 1) {
                 System.out.print(", ");

--- a/2DX-GL/snap2d/src/main/java/com/snap2d/script/Flags.java
+++ b/2DX-GL/snap2d/src/main/java/com/snap2d/script/Flags.java
@@ -1,12 +1,12 @@
 /*
  *  Copyright (C) 2011-2014 Brian Groenke
  *  All rights reserved.
- * 
+ *
  *  This file is part of the 2DX Graphics Library.
  *
  *  This Source Code Form is subject to the terms of the
- *  Mozilla Public License, v. 2.0. If a copy of the MPL 
- *  was not distributed with this file, You can obtain one at 
+ *  Mozilla Public License, v. 2.0. If a copy of the MPL
+ *  was not distributed with this file, You can obtain one at
  *  http://mozilla.org/MPL/2.0/.
  */
 
@@ -15,7 +15,7 @@ package com.snap2d.script;
 /**
  * Flags used by compiler and engine internally to represent types using
  * primitives.
- * 
+ *
  * @author Brian Groenke
  */
 public final class Flags {
@@ -67,7 +67,7 @@ public final class Flags {
      */
 
     // engine main execution completion status signals
-    public static final int RETURN = 0xFD000000, BREAK = 0xFD000001;
+    public static final int RETURN = 0xFD000000, BREAK = 0xFD000001, END = 0xFD000001;
 
     /*
      * Pre-compiler signals

--- a/2DX-GL/snap2d/src/main/java/com/snap2d/script/ScriptInvocationException.java
+++ b/2DX-GL/snap2d/src/main/java/com/snap2d/script/ScriptInvocationException.java
@@ -1,12 +1,12 @@
 /*
  *  Copyright (C) 2011-2014 Brian Groenke
  *  All rights reserved.
- * 
+ *
  *  This file is part of the 2DX Graphics Library.
  *
  *  This Source Code Form is subject to the terms of the
- *  Mozilla Public License, v. 2.0. If a copy of the MPL 
- *  was not distributed with this file, You can obtain one at 
+ *  Mozilla Public License, v. 2.0. If a copy of the MPL
+ *  was not distributed with this file, You can obtain one at
  *  http://mozilla.org/MPL/2.0/.
  */
 
@@ -19,7 +19,7 @@ package com.snap2d.script;
 public class ScriptInvocationException extends Exception {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = 2687331964728629451L;
 
@@ -30,7 +30,7 @@ public class ScriptInvocationException extends Exception {
 
         super(message);
         this.func = f;
-        msg = "error executing function '" + f.getName() + "' [fid=" + f.getID() + "]";
+        msg = "error executing function '" + f.getName() + "' [fid=" + f.getID() + "] @ pos=" + (f.bytecode.position() - 1);
     }
 
     public Function getTargetFunction() {

--- a/2DX-GL/snap2d/src/main/java/com/snap2d/script/ScriptUI.java
+++ b/2DX-GL/snap2d/src/main/java/com/snap2d/script/ScriptUI.java
@@ -1,12 +1,12 @@
 /*
  *  Copyright (C) 2011-2014 Brian Groenke
  *  All rights reserved.
- * 
+ *
  *  This file is part of the 2DX Graphics Library.
  *
  *  This Source Code Form is subject to the terms of the
- *  Mozilla Public License, v. 2.0. If a copy of the MPL 
- *  was not distributed with this file, You can obtain one at 
+ *  Mozilla Public License, v. 2.0. If a copy of the MPL
+ *  was not distributed with this file, You can obtain one at
  *  http://mozilla.org/MPL/2.0/.
  */
 
@@ -33,19 +33,21 @@ import java.util.Calendar;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 
+import com.snap2d.gl.opengl.GLUtils;
+
 import bg.x2d.utils.Utils;
 
 /**
  * A graphical interface utility that allows for live script
  * compilation/execution.
- * 
+ *
  * @author Brian Groenke
  *
  */
 public class ScriptUI extends JFrame {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -7280184562521580572L;
 
@@ -211,6 +213,7 @@ public class ScriptUI extends JFrame {
                 try {
                     output.setText(new SimpleDateFormat("HH:mm:ss:SSS").format(Calendar.getInstance().getTime())
                             + "\n<Executing script function: invocation target -> fid=" + f.getID() + ">\n\n");
+                    f.bytecode.rewind();
                     Object ret = prog.invoke(f, args);
                     lastRun = f;
                     lastRunArgs = args;
@@ -248,7 +251,7 @@ public class ScriptUI extends JFrame {
     private class RunDialog extends JDialog {
 
         /**
-         * 
+         *
          */
         private static final long serialVersionUID = -473771619157816946L;
 


### PR DESCRIPTION
-Fix recursive function calls failing with 'unexpected bytecode instruction' errors (Resolves #9)
-Fix return not working properly from within blocks (outside-block context would continue executing).
-ScriptInvocationException now includes the position in the function bytecode buffer where the error occurred.